### PR TITLE
Removes a redundant call to `getBytes`

### DIFF
--- a/src/main/java/bz/turtle/readable/ReadableModel.java
+++ b/src/main/java/bz/turtle/readable/ReadableModel.java
@@ -513,7 +513,6 @@ public class ReadableModel {
       if (c >= '0' && c <= '9') {
         result = 10 * result + c - '0';
       } else {
-        byte[] d = s.getBytes();
         return VWMurmur.hash(s, seed);
       }
     }


### PR DESCRIPTION
This was an oversight in my previous fix. The redundant call is innocuous, so it shouldn't be a cause for bugs.