### PR TITLE
Reduce Garbage Collection form String usage

### DIFF
--- a/src/main/java/bz/turtle/readable/ReadableModel.java
+++ b/src/main/java/bz/turtle/readable/ReadableModel.java
@@ -500,10 +500,10 @@ public class ReadableModel {
    */
   public int featureHashOf(int mmNamespaceHash, FeatureInterface feature) {
     if (hashAll) {
-      return VWMurmur.hash(feature.getStringName(), mmNamespaceHash);
+      return VWMurmur.hash(feature.getBytes(), mmNamespaceHash);
     } else {
       if (feature.hasIntegerName()) return feature.getIntegerName() + mmNamespaceHash;
-      return VWMurmur.hash(feature.getStringName(), mmNamespaceHash);
+      return VWMurmur.hash(feature.getBytes(), mmNamespaceHash);
     }
   }
 
@@ -515,7 +515,7 @@ public class ReadableModel {
    *     https://github.com/JohnLangford/vowpal_wabbit/blob/579c34d2d2fd151b419bea54d9921fc7f3f55bbc/vowpalwabbit/parse_primitives.cc#L48
    */
   public int namespaceHashOf(Namespace namespace, int seed) {
-    String s = namespace.namespace;
+    StringBuilder s = namespace.namespace;
 
     if (hashAll) return VWMurmur.hash(s, seed);
 
@@ -724,7 +724,28 @@ public class ReadableModel {
                           });
                     }));
       } else {
-        input.namespaces.sort(Comparator.comparing(ans -> ans.namespace));
+        input.namespaces.sort(new Comparator<Namespace>() {
+          @Override
+          public int compare(Namespace o1, Namespace o2) {
+            return compare(o1.namespace, o2.namespace);
+          }
+
+          private int compare(StringBuilder o1, StringBuilder o2) {
+            int len1 = o1.length();
+            int len2 = o2.length();
+            int lim = Math.min(len1, len2);
+            int k = 0;
+            while (k < lim) {
+              char c1 = o1.charAt(k);
+              char c2 = o2.charAt(k);
+              if (c1 != c2) {
+                return c1 - c2;
+              }
+              k++;
+            }
+            return len1 - len2;
+          }
+        });
 
         for (int i = 0; i < input.namespaces.size(); i++) {
           Namespace ans = input.namespaces.get(i);

--- a/src/main/java/bz/turtle/readable/VWMurmur.java
+++ b/src/main/java/bz/turtle/readable/VWMurmur.java
@@ -1,5 +1,7 @@
 package bz.turtle.readable;
 
+import java.nio.ByteBuffer;
+
 /**
  * copy paste reimplementation from explore/hash.h in JohnLangford/vowpal_wabbit since i couldnt
  * find published murmur for java that returns the same hash as VW so i had to copy it
@@ -18,12 +20,13 @@ public class VWMurmur {
     return h;
   }
 
-  public static int hash(String s, int seed) {
-    byte[] d = s.getBytes();
-    return hash(d, d.length, seed);
+  public static int hash(StringBuilder s, int seed) {
+    ByteBuffer d = ByteBuffer.wrap(s.toString().getBytes());
+    return hash(d, seed);
   }
 
-  public static int hash(byte[] data, int len, int seed) {
+  public static int hash(ByteBuffer data, int seed) {
+    int len = data.limit();
     int nblocks = len / 4;
     int h1 = seed;
     int c1 = 0xcc9e2d51;
@@ -31,7 +34,7 @@ public class VWMurmur {
 
     int i = 0;
     while (i <= len - 4) {
-      int k1 = (data[i] | data[i + 1] << 8 | data[i + 2] << 16 | data[i + 3] << 24);
+      int k1 = (data.get(i) | data.get(i + 1) << 8 | data.get(i + 2) << 16 | data.get(i + 3) << 24);
 
       k1 *= c1;
       k1 = rotl32(k1, 15);
@@ -48,11 +51,11 @@ public class VWMurmur {
     int end = (nblocks * 4);
     switch (len & 3) {
       case 3:
-        k1 ^= (int) data[end + 2] << 16;
+        k1 ^= (int) data.get(end + 2) << 16;
       case 2:
-        k1 ^= (int) data[end + 1] << 8;
+        k1 ^= (int) data.get(end + 1) << 8;
       case 1:
-        k1 ^= (int) data[end];
+        k1 ^= (int) data.get(end);
 
         k1 *= c1;
         k1 = rotl32(k1, 15);

--- a/src/main/java/bz/turtle/readable/input/Feature.java
+++ b/src/main/java/bz/turtle/readable/input/Feature.java
@@ -120,7 +120,7 @@ public class Feature implements FeatureInterface {
     resetIsHashComputed();
   }
 
-  public void rename(StringBuilder name) {
+  public void rename(CharSequence name) {
     this.setName(name);
     resetIsHashComputed();
   }

--- a/src/main/java/bz/turtle/readable/input/Feature.java
+++ b/src/main/java/bz/turtle/readable/input/Feature.java
@@ -167,13 +167,13 @@ public class Feature implements FeatureInterface {
   /**
    * @return the string name, recomputed from nameInt if needed @see getIntegerName
    */
-  public StringBuilder getStringName() {
+  public String getStringName() {
     if (!isStringNameComputed) {
       this.name.setLength(0);
       this.name.append(this.nameInt);
       this.isStringNameComputed = true;
     }
-    return name;
+    return name.toString();
   }
 
   public ByteBuffer getBytes() {

--- a/src/main/java/bz/turtle/readable/input/Feature.java
+++ b/src/main/java/bz/turtle/readable/input/Feature.java
@@ -1,58 +1,81 @@
 package bz.turtle.readable.input;
 
+import sun.nio.cs.ThreadLocalCoders;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
 /**
  * We compute the hash value only once do not reuse between namespaces because the hash is dependent
  * on the namespace hash
  */
 public class Feature implements FeatureInterface {
+  /**
+   * used so we dont recompute the hash value of the feature
+   */
+  private static final Charset charset = StandardCharsets.UTF_8;
+  /**
+   * used so we dont recompute the hash value of the feature
+   */
+  public transient int computedHashValue;
+  public transient boolean hashIsComputed = false;
   private int nameInt;
   private float value = 1f;
-
   private boolean isStringNameComputed = false;
-  /** used so we dont recompute the hash value of the feature */
-  public transient int computedHashValue;
-  /** used so we dont recompute the hash value of the feature */
-  public transient boolean hashIsComputed = false;
-
-  private String name;
+  private boolean isBytesNameComputed = false;
+  private StringBuilder name;
   private boolean hasIntegerName;
+  private int bufferSize = 10240;
+  private CharBuffer charBuffer = CharBuffer.wrap(new char[bufferSize]);
+  private ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[bufferSize]);
 
-  public boolean hasIntegerName() {
-    return hasIntegerName;
+  public Feature() {
   }
 
-  public Feature() {}
+  public Feature(StringBuilder name) {
+    this(name, 1);
+  }
 
   public Feature(String name) {
-    this(name, 1);
+    this(new StringBuilder(name), 1);
   }
 
   public Feature(int name) {
     this(name, 1);
   }
 
-  public Feature(String name, float value) {
+  public Feature(CharSequence name, float value) {
+    this.name = new StringBuilder();
     this.setName(name);
     this.setValue(value);
+  }
+
+  public Feature(String name, float value) {
+    this(new StringBuilder(name), value);
   }
 
   public Feature(int name, float v) {
     this.name = null;
     this.isStringNameComputed = false;
     if (name < 0) {
-      rename("" + name);
+      rename(name);
     } else {
       this.setNameInt(name);
     }
     this.setValue(v);
   }
 
-  private static boolean isPositiveInteger(String s) {
+  private static boolean isPositiveInteger(CharSequence s) {
     return isPositiveInteger(s, 10);
   }
 
-  private static boolean isPositiveInteger(String s, int radix) {
-    if (s.isEmpty()) return false;
+  private static boolean isPositiveInteger(CharSequence s, int radix) {
+    if (s.length() == 0) return false;
     for (int i = 0; i < s.length(); i++) {
       if (i == 0 && s.charAt(i) == '-') {
         return false;
@@ -72,6 +95,10 @@ public class Feature implements FeatureInterface {
     return new Feature(name, value);
   }
 
+  public boolean hasIntegerName() {
+    return hasIntegerName;
+  }
+
   @Override
   public String toString() {
     return String.format("%s[%d]:%f", getStringName(), this.getIntegerName(), getValue());
@@ -84,22 +111,38 @@ public class Feature implements FeatureInterface {
    */
   public void rename(int name) {
     if (name < 0) {
-      rename("" + name);
+      this.setName(name);
     } else {
       this.setNameInt(name);
       this.isStringNameComputed = false;
+      this.isBytesNameComputed = false;
       resetIsHashComputed();
     }
   }
 
-  public void rename(String name) {
+  public void rename(StringBuilder name) {
+    this.setName(name);
+    resetIsHashComputed();
+  }
+
+  public void rename(double name) {
+    this.setName(name);
+    resetIsHashComputed();
+  }
+
+  public void rename(float name) {
+    this.setName(name);
+    resetIsHashComputed();
+  }
+
+  public void rename(long name) {
     this.setName(name);
     resetIsHashComputed();
   }
 
   /**
-   * --hash strings vs --hash all, in case the feature value is integer, there is no need to convert
-   * it to string
+   * --hash strings vs --hash all, in case the feature value is integer, there is no need to
+   * convert it to string
    */
   public int getIntegerName() {
     return nameInt;
@@ -110,7 +153,9 @@ public class Feature implements FeatureInterface {
     this.hasIntegerName = true;
   }
 
-  /** feature value */
+  /**
+   * feature value
+   */
   public float getValue() {
     return value;
   }
@@ -119,34 +164,102 @@ public class Feature implements FeatureInterface {
     this.value = value;
   }
 
-  /** @return the string name, recomputed from nameInt if needed @see getIntegerName */
-  public String getStringName() {
+  /**
+   * @return the string name, recomputed from nameInt if needed @see getIntegerName
+   */
+  public StringBuilder getStringName() {
     if (!isStringNameComputed) {
-      this.name = "" + this.nameInt;
+      this.name.setLength(0);
+      this.name.append(this.nameInt);
       this.isStringNameComputed = true;
     }
     return name;
   }
 
-  private void setName(String name) {
+  public ByteBuffer getBytes() {
+    if (!isBytesNameComputed) {
+      this.setByteBuffer();
+    }
+    return this.byteBuffer;
+  }
+
+  private void setName(CharSequence name) {
     if (isPositiveInteger(name)) {
       try {
-        setNameInt(Integer.parseInt(name));
+        setNameInt(Util.parseInt(name));
       } catch (Exception e) {
       }
     }
 
     this.isStringNameComputed = true;
-    this.name = name;
+    this.name.setLength(0);
+    this.name.append(name);
+    this.setByteBuffer();
+  }
+
+  private void setName(int name) {
+    if (name > 0) {
+      try {
+        setNameInt(name);
+      } catch (Exception e) {
+      }
+    }
+
+    this.isStringNameComputed = true;
+    this.name.setLength(0);
+    this.name.append(name);
+    this.setByteBuffer();
+  }
+
+  private void setName(double name) {
+    this.isStringNameComputed = true;
+    this.name.setLength(0);
+    this.name.append(name);
+    this.setByteBuffer();
+  }
+
+  private void setName(long name) {
+    this.isStringNameComputed = true;
+    this.name.setLength(0);
+    this.name.append(name);
+    this.setByteBuffer();
+  }
+
+  private void setName(float name) {
+    this.isStringNameComputed = true;
+    this.name.setLength(0);
+    this.name.append(name);
+    this.setByteBuffer();
+  }
+
+  private void setByteBuffer() {
+    this.charBuffer.clear();
+    this.byteBuffer.clear();
+
+    CharsetEncoder ce = ThreadLocalCoders.encoderFor(charset)
+        .onMalformedInput(CodingErrorAction.REPLACE)
+        .onUnmappableCharacter(CodingErrorAction.REPLACE)
+        .reset();
+
+
+    for (int i = 0; i < this.name.length(); i++) {
+      this.charBuffer.put(this.name.charAt(i));
+    }
+    this.charBuffer.flip();
+    try {
+      Util.encode(ce, this.charBuffer, this.byteBuffer);
+    } catch (CharacterCodingException e ) {
+    }
+    this.isBytesNameComputed = true;
+  }
+
+  public int getComputedHash() {
+    return computedHashValue;
   }
 
   public void setComputedHash(int n) {
     this.computedHashValue = n;
     this.hashIsComputed = true;
-  }
-
-  public int getComputedHash() {
-    return computedHashValue;
   }
 
   public boolean isHashComputed() {

--- a/src/main/java/bz/turtle/readable/input/Feature.java
+++ b/src/main/java/bz/turtle/readable/input/Feature.java
@@ -116,8 +116,8 @@ public class Feature implements FeatureInterface {
       this.setNameInt(name);
       this.isStringNameComputed = false;
       this.isBytesNameComputed = false;
-      resetIsHashComputed();
     }
+    resetIsHashComputed();
   }
 
   public void rename(StringBuilder name) {

--- a/src/main/java/bz/turtle/readable/input/FeatureInterface.java
+++ b/src/main/java/bz/turtle/readable/input/FeatureInterface.java
@@ -13,7 +13,7 @@ public interface FeatureInterface {
 
   float getValue();
 
-  void rename(StringBuilder name);
+  void rename(CharSequence name);
 
   void rename(int name);
 

--- a/src/main/java/bz/turtle/readable/input/FeatureInterface.java
+++ b/src/main/java/bz/turtle/readable/input/FeatureInterface.java
@@ -7,7 +7,7 @@ public interface FeatureInterface {
 
   int getIntegerName();
 
-  StringBuilder getStringName();
+  String getStringName();
 
   ByteBuffer getBytes();
 

--- a/src/main/java/bz/turtle/readable/input/FeatureInterface.java
+++ b/src/main/java/bz/turtle/readable/input/FeatureInterface.java
@@ -1,21 +1,31 @@
 package bz.turtle.readable.input;
 
+import java.nio.ByteBuffer;
+
 public interface FeatureInterface {
   boolean hasIntegerName();
 
   int getIntegerName();
 
-  String getStringName();
+  StringBuilder getStringName();
+
+  ByteBuffer getBytes();
 
   float getValue();
 
-  void rename(String name);
+  void rename(StringBuilder name);
 
   void rename(int name);
 
-  void setComputedHash(int h);
+  void rename(double name);
+
+  void rename(float name);
+
+  void rename(long name);
 
   int getComputedHash();
+
+  void setComputedHash(int h);
 
   void resetIsHashComputed();
 

--- a/src/main/java/bz/turtle/readable/input/Namespace.java
+++ b/src/main/java/bz/turtle/readable/input/Namespace.java
@@ -13,7 +13,7 @@ import java.util.List;
  * on the model seed
  */
 public class Namespace implements Serializable {
-  public String namespace;
+  public StringBuilder namespace;
   public List<FeatureInterface> features;
 
   public transient int computedHashValue;
@@ -23,9 +23,13 @@ public class Namespace implements Serializable {
     this("");
   }
 
-  public Namespace(String ns) {
+  public Namespace(StringBuilder ns) {
     this.namespace = ns;
     features = new ArrayList<>();
+  }
+
+  public Namespace(String ns) {
+    this(new StringBuilder(ns));
   }
 
   @Override
@@ -33,9 +37,13 @@ public class Namespace implements Serializable {
     return String.format("{%s: %s}", namespace, features.toString());
   }
 
-  public Namespace(String ns, FeatureInterface... features) {
+  public Namespace(StringBuilder ns, FeatureInterface... features) {
     this.namespace = ns;
     this.features = Arrays.asList(features);
+  }
+
+  public Namespace(String ns, FeatureInterface... features) {
+    this(new StringBuilder(ns), features);
   }
 
   /**
@@ -43,10 +51,15 @@ public class Namespace implements Serializable {
    *
    * @param name - the new namespace name
    */
-  public void rename(String name) {
-    this.namespace = name;
+  public void rename(StringBuilder name) {
+    this.namespace.setLength(0);
+    this.namespace.append(name);
     computedHashValue = 0;
     hashIsComputed = false;
-    features.forEach(f -> f.resetIsHashComputed());
+    features.forEach(FeatureInterface::resetIsHashComputed);
+  }
+
+  public void rename(String name) {
+    this.rename(new StringBuilder(name));
   }
 }

--- a/src/main/java/bz/turtle/readable/input/Util.java
+++ b/src/main/java/bz/turtle/readable/input/Util.java
@@ -1,0 +1,94 @@
+package bz.turtle.readable.input;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+
+class Util {
+    static int parseInt(CharSequence s)
+            throws NumberFormatException {
+        /*
+         * WARNING: This method may be invoked early during VM initialization
+         * before IntegerCache is initialized. Care must be taken to not use
+         * the valueOf method.
+         */
+
+        int radix = 10;
+        if (s == null) {
+            throw new NumberFormatException("null");
+        }
+
+        int result = 0;
+        boolean negative = false;
+        int i = 0, len = s.length();
+        int limit = -Integer.MAX_VALUE;
+        int multmin;
+        int digit;
+
+        if (len > 0) {
+            char firstChar = s.charAt(0);
+            if (firstChar < '0') { // Possible leading "+" or "-"
+                if (firstChar == '-') {
+                    negative = true;
+                    limit = Integer.MIN_VALUE;
+                } else if (firstChar != '+')
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
+
+                if (len == 1) // Cannot have lone "+" or "-"
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
+                i++;
+            }
+            multmin = limit / radix;
+            while (i < len) {
+                // Accumulating negatively avoids surprises near MAX_VALUE
+                digit = Character.digit(s.charAt(i++), radix);
+                if (digit < 0) {
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
+                }
+                if (result < multmin) {
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
+                }
+                result *= radix;
+                if (result < limit + digit) {
+                    throw new NumberFormatException("For input string: \"" + s + "\"");
+                }
+                result -= digit;
+            }
+        } else {
+            throw new NumberFormatException("For input string: \"" + s + "\"");
+        }
+        return negative ? result : -result;
+    }
+
+    static ByteBuffer encode(CharsetEncoder ce, CharBuffer in, ByteBuffer out)
+            throws CharacterCodingException {
+        int n = (int) (in.remaining() * ce.averageBytesPerChar());
+
+        if ((n == 0) && (in.remaining() == 0))
+            return out;
+        ce.reset();
+        for (; ; ) {
+            CoderResult cr = in.hasRemaining()
+                    ? ce.encode(in, out, true)
+                    : CoderResult.UNDERFLOW;
+            if (cr.isUnderflow())
+                cr = ce.flush(out);
+
+            if (cr.isUnderflow())
+                break;
+            if (cr.isOverflow()) {
+                n = 2 * n + 1;    // Ensure progress; n might be 0!
+                ByteBuffer o = ByteBuffer.allocate(n);
+                out.flip();
+                o.put(out);
+                out = o;
+                continue;
+            }
+            cr.throwException();
+        }
+        out.flip();
+        return out;
+    }
+}


### PR DESCRIPTION
While processing a large number of features, we noticed
Garbage Collection cycles of > 10 seconds. This was due to the
large number of created strings used to encode and decode the
feature names.

This commit sets the feature names to be resuable String builders
and exposes methods to setName as int, double, String, float and long.
The murmur hash function now also accepts ByteBuffers that are reusable
and are created when the feature is initially created and are reused
and reset along with the string builder objects and the encompassing
reusable CharBuffer as well.

The StringBuilder is kept there to be able to easily debug, althoug it
adds a bit more memory, it is reusable memory and very predictable in
terms of added Garbage for the JVM to take care of.